### PR TITLE
Fixes the issue whereby in the jenkins/docker setup, mysql doesn't st…

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -88,6 +88,19 @@
   service: name={{ mysql_daemon }} state=started
   ignore_errors: yes # This command errors because of the issue below
 
+- name: mysql status
+  command: service mysql status
+  register: out
+  ignore_errors: yes
+  
+- debug: var=out.stdout_lines
+
+- name: mysql start
+  command: service mysql start
+  register: out
+
+- debug: var=out.stdout_lines
+
 - name: Grant debian-sys-maint permissions to DB http://serverfault.com/questions/9948/what-is-the-debian-sys-maint-mysql-user-and-more
   shell: >
     mysql -u root -NBe
@@ -98,3 +111,5 @@
 - name: Ensure MySQL is started and enabled on boot.
   service: name={{ mysql_daemon }} state=started enabled="{{ mysql_enabled_on_startup }}"
   register: mysql_service_configuration
+
+- debug: var=mysql_service_configuration


### PR DESCRIPTION
Do not merge, related to https://bitbucket.org/flyvictor/wordpress-consumer-frontend/pull-requests/218/web-15604-build-with-jenkins-2/diff

This helps resolve the issue whereby mysql doesn't start correctly, resulting in subsequent commands failing, as seen here:

https://craigedmunds.ci.cloudbees.com/job/wordpress-consumer-frontend/job/WEB-15604-build-with-jenkins/41/console

It's just doing the same as the "Ensure MySQL is started and enabled on boot" task above, but for whatever reason that isn't working
